### PR TITLE
feat(poc): add neuro-symbolic architecture stub (issue #1)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,18 +13,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: |
-            poc/requirements.txt
-            poc/requirements-dev.txt
+
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-pip-${{ hashFiles('poc/requirements.txt', 'poc/requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-pip-
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r poc/requirements-dev.txt
+          pip install --prefer-binary -r poc/requirements-dev.txt
 
       - name: Run test suite
         run: pytest poc/tests/ -v

--- a/poc/architectures/__init__.py
+++ b/poc/architectures/__init__.py
@@ -1,4 +1,5 @@
 from .base import BaseArchitecture, InferenceOutput
+from .neurosymbolic import NeuroSymbolicArchitecture
 from .ssm_proxy import SSMProxyArchitecture
 from .transformer import (
     TransformerArchitecture,
@@ -9,6 +10,7 @@ from .transformer import (
 __all__ = [
     "BaseArchitecture",
     "InferenceOutput",
+    "NeuroSymbolicArchitecture",
     "SSMProxyArchitecture",
     "TransformerArchitecture",
     "check_ollama_available",

--- a/poc/architectures/neurosymbolic.py
+++ b/poc/architectures/neurosymbolic.py
@@ -42,7 +42,7 @@ class NeuroSymbolicArchitecture(BaseArchitecture):
         model: str = "z-ai/glm-4.5-air:free",
         temperature: float = 0.1,
         provider: str = "openrouter",
-    ):
+    ) -> None:
         self.model = model
         self.temperature = temperature
         self.provider = provider
@@ -86,9 +86,9 @@ class NeuroSymbolicArchitecture(BaseArchitecture):
         if self.provider == "ollama":
             import ollama
 
-            messages = [{"role": "system", "content": system_prompt}]
             if context:
-                messages.append({"role": "system", "content": f"Context:\n{context}"})
+                system_prompt = f"{system_prompt}\n\nContext:\n{context}"
+            messages = [{"role": "system", "content": system_prompt}]
             messages.append({"role": "user", "content": query})
 
             response = ollama.chat(
@@ -113,7 +113,7 @@ class NeuroSymbolicArchitecture(BaseArchitecture):
         if self.provider == "mock":
             output = (
                 "Premises:\n"
-                f"- {_rule_extract_premises(query)}\n"
+                f"- {premise_hint}\n"
                 "Assumptions:\n"
                 "- Limited information beyond the query text.\n"
                 "Reasoning:\n"

--- a/poc/architectures/neurosymbolic.py
+++ b/poc/architectures/neurosymbolic.py
@@ -1,0 +1,135 @@
+from typing import Optional
+
+from .base import BaseArchitecture, InferenceOutput
+from .openrouter import chat_openrouter
+
+
+SYSTEM_PROMPT_NEUROSYMBOLIC = """You are a neuro-symbolic reasoning agent.
+Decompose the query into explicit premises and a conclusion.
+List assumptions separately from facts.
+Flag uncertainty explicitly when data is missing.
+Use concise, structured reasoning.
+
+Output format:
+Premises:
+- ...
+Assumptions:
+- ...
+Reasoning:
+- ...
+Conclusion:
+- ..."""
+
+
+def _rule_extract_premises(query: str) -> str:
+    """Simple rule-based extraction used as a Phase 0 neuro-symbolic stub."""
+    q = query.strip().rstrip("?")
+    if not q:
+        return "No explicit premise provided."
+    return f"Input query asks to analyze: {q}."
+
+
+class NeuroSymbolicArchitecture(BaseArchitecture):
+    """
+    Neuro-symbolic architecture stub for Phase 0.
+
+    This is not a full symbolic reasoner. It combines a rule-based premise
+    extraction hint with an LLM response style constrained to explicit logic.
+    """
+
+    def __init__(
+        self,
+        model: str = "z-ai/glm-4.5-air:free",
+        temperature: float = 0.1,
+        provider: str = "openrouter",
+    ):
+        self.model = model
+        self.temperature = temperature
+        self.provider = provider
+
+    @property
+    def architecture_type(self) -> str:
+        return "neurosymbolic"
+
+    @property
+    def model_id(self) -> str:
+        return f"{self.provider}/{self.model} (neurosymbolic-stub)"
+
+    def infer(self, query: str, context: Optional[str] = None) -> InferenceOutput:
+        premise_hint = _rule_extract_premises(query)
+        system_prompt = f"{SYSTEM_PROMPT_NEUROSYMBOLIC}\n\nRule-based premise hint:\n{premise_hint}"
+
+        if self.provider == "openrouter":
+            response = chat_openrouter(
+                model=self.model,
+                system_prompt=system_prompt,
+                query=query,
+                context=context,
+                temperature=self.temperature,
+                max_tokens=320,
+                timeout_s=30.0,
+            )
+            return InferenceOutput(
+                architecture=self.architecture_type,
+                query=query,
+                output=response["content"],
+                latency_ms=0.0,
+                model_id=self.model_id,
+                metadata={
+                    "provider": "openrouter",
+                    "stub": True,
+                    "mode": "rule-augmented-llm",
+                    "usage": response.get("usage", {}),
+                },
+            )
+
+        if self.provider == "ollama":
+            import ollama
+
+            messages = [{"role": "system", "content": system_prompt}]
+            if context:
+                messages.append({"role": "system", "content": f"Context:\n{context}"})
+            messages.append({"role": "user", "content": query})
+
+            response = ollama.chat(
+                model=self.model,
+                messages=messages,
+                options={"temperature": self.temperature, "num_predict": 512},
+            )
+
+            return InferenceOutput(
+                architecture=self.architecture_type,
+                query=query,
+                output=response["message"]["content"].strip(),
+                latency_ms=0.0,
+                model_id=self.model_id,
+                metadata={
+                    "provider": "ollama",
+                    "stub": True,
+                    "mode": "rule-augmented-llm",
+                },
+            )
+
+        if self.provider == "mock":
+            output = (
+                "Premises:\n"
+                f"- {_rule_extract_premises(query)}\n"
+                "Assumptions:\n"
+                "- Limited information beyond the query text.\n"
+                "Reasoning:\n"
+                "- Build a minimal logical chain from stated premises.\n"
+                "Conclusion:\n"
+                f"- [mock-neurosymbolic] {query[:150]}"
+            )
+            return InferenceOutput(
+                architecture=self.architecture_type,
+                query=query,
+                output=output,
+                latency_ms=0.0,
+                model_id=self.model_id,
+                metadata={"provider": "mock", "stub": True, "mode": "rule-based"},
+            )
+
+        raise ValueError(
+            f"Unsupported provider '{self.provider}'. Use 'openrouter', 'ollama', or 'mock'."
+        )

--- a/poc/tests/test_architectures.py
+++ b/poc/tests/test_architectures.py
@@ -1,0 +1,29 @@
+from poc.architectures import (
+    NeuroSymbolicArchitecture,
+    SSMProxyArchitecture,
+    TransformerArchitecture,
+)
+from poc.convergence import compute_coherence_score
+
+
+def test_neurosymbolic_infer_returns_output() -> None:
+    model = NeuroSymbolicArchitecture(provider="mock")
+    result = model.infer("What is 2+2?")
+    assert result.architecture == "neurosymbolic"
+    assert isinstance(result.output, str)
+    assert result.output.strip() != ""
+
+
+def test_three_architecture_coherence_runs() -> None:
+    query = "Explain why deterministic proofs improve trust in distributed systems."
+    transformer = TransformerArchitecture(provider="mock")
+    ssm = SSMProxyArchitecture(provider="mock")
+    neuro = NeuroSymbolicArchitecture(provider="mock")
+
+    out_t = transformer.infer(query).output
+    out_s = ssm.infer(query).output
+    out_n = neuro.infer(query).output
+
+    result = compute_coherence_score(out_t, out_s, out_n)
+    assert 0.0 <= result.score <= 1.0
+    assert result.output_n == out_n


### PR DESCRIPTION
## Summary
- add `NeuroSymbolicArchitecture` stub in PoC architecture layer
- support `openrouter`, `ollama`, and `mock` providers with explicit logical-decomposition prompt
- export the new architecture in `poc.architectures`
- add tests validating neuro-symbolic inference and 3-architecture coherence computation

## Validation
- `.venv/bin/python -m pytest poc/tests/test_architectures.py poc/tests/test_coherence.py -q`

Closes #1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced NeuroSymbolicArchitecture, a new inference capability combining rule-based premise extraction with LLM-assisted reasoning. Supports multiple inference providers for flexible deployment.

* **Tests**
  * Added comprehensive tests for the new neuro-symbolic architecture and multi-architecture coherence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->