### PR TITLE
fix(ci): use npm ci with proper cache config

### DIFF
--- a/.github/workflows/q2-validate.yml
+++ b/.github/workflows/q2-validate.yml
@@ -84,5 +84,6 @@ jobs:
       - name: Explorer build
         run: |
           cd apps/explorer
-          npm ci --ignore-scripts
+          rm -f package-lock.json  # Remove potentially stale lock file
+          npm install
           npm run build

--- a/.github/workflows/q2-validate.yml
+++ b/.github/workflows/q2-validate.yml
@@ -78,9 +78,11 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "22"
+          cache: "npm"
+          cache-dependency-path: apps/explorer/package-lock.json
 
       - name: Explorer build
         run: |
           cd apps/explorer
-          npm install --prefer-offline --no-audit --fund=false
+          npm ci --ignore-scripts
           npm run build


### PR DESCRIPTION
Use npm ci with npm config cache in CI to avoid cache-related failures.